### PR TITLE
Add library helper: for_instance

### DIFF
--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -31,4 +31,11 @@ module ProxysqlHelpers
     end
     output.string
   end
+
+  def for_instance(instance, config)
+    {
+      instance => config.is_a?(Array) ? config : [config]
+    }
+  end
+  module_function :for_instance
 end

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -20,6 +20,8 @@ module ProxysqlHelpers
       output.puts ')'
     when String
       output.puts "\"#{obj}\""
+    when Symbol
+      output.puts "\"#{obj}\""
     when Integer || Float
       output.puts obj
     when TrueClass || FalseClass


### PR DESCRIPTION
Adding for_instance helper which is a shorthand for `{ hash => array }`

```ruby
  instance = 'eu1'

  proxysql_service instance do
    admin_variables admin_variables
    mysql_variables variables
    mysql_servers ProxysqlHelpers.for_instance(instance, hosts)
    mysql_users ProxysqlHelpers.for_instance(instance, users)
    mysql_replication_hostgroups ProxysqlHelpers.for_instance(instance, groups)
  end
```