### PR TITLE
Create proxysql group only if creating user

### DIFF
--- a/libraries/base_service.rb
+++ b/libraries/base_service.rb
@@ -82,13 +82,14 @@ class Chef
 
       def create_user
         group new_resource.group do
-          action :create
+          action :nothing
         end
 
         user new_resource.user do
           group new_resource.group
           shell '/bin/false'
           action :create
+          notifies :create, "group[#{new_resource.group}]", :before
         end
       end
 

--- a/test/integration/default/user.rb
+++ b/test/integration/default/user.rb
@@ -1,0 +1,7 @@
+describe user('proxysql') do
+  it { should exist }
+end
+
+describe group('proxysql') do
+  it { should exist }
+end


### PR DESCRIPTION
This fixes ProxySQL group overrides when other members are appended to `proxysql` group