### PR TITLE
Handle multiple admin mysql interfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,6 @@
 ProxySQL is a high performance, high availability, protocol aware proxy
 for MySQL and forks (like Percona Server and MariaDB).
 
-> Note: due to rapid ProxySQL development, locked ProxySQL version may not be available, therefore one might need to bump version `node['proxysql']['version']`.
-
 [![Build Status](https://travis-ci.org/vinted/chef-proxysql.svg?branch=master)](https://travis-ci.org/vinted/chef-proxysql)
 [![Cookbook Version](https://img.shields.io/cookbook/v/proxysql.svg)](https://supermarket.chef.io/cookbooks/proxysql)
 

--- a/attributes/repository.rb
+++ b/attributes/repository.rb
@@ -1,24 +1,13 @@
-default['percona']['repository']['name'] = 'percona-release.repo'
-default['percona']['repository']['version'] = '0.1-4'
+default['percona']['repository']['name'] = 'percona-original-release.repo'
 
 case node['platform']
 when 'rhel', 'centos'
-  default['proxysql']['package_release'] = "1.1.el#{node['platform_version'].to_i}"
-
-  default['percona']['repository']['url'] = 'http://www.percona.com/'\
-    'downloads/percona-release/redhat/'\
-    "#{node['percona']['repository']['version']}/"\
-    "percona-release-#{node['percona']['repository']['version']}.noarch.rpm"
+  default['percona']['repository']['url'] = 'http://repo.percona.com/yum/percona-release-latest.noarch.rpm'
 when 'debian', 'ubuntu'
   lsb_release = Mixlib::ShellOut.new('lsb_release -sc')
   lsb_release.run_command
   lsb_release.error!
   lsb_release = lsb_release.stdout.chomp
 
-  default['proxysql']['package_release'] = "1.1.#{lsb_release}"
-
-  default['percona']['repository']['url'] =
-    'http://repo.percona.com/apt/percona-release_'\
-    "#{node['percona']['repository']['version']}."\
-    "#{lsb_release}_all.deb"
+  default['percona']['repository']['url'] = "http://repo.percona.com/apt/percona-release_latest.#{lsb_release}_all.deb"
 end

--- a/libraries/proxysql_service.rb
+++ b/libraries/proxysql_service.rb
@@ -184,11 +184,13 @@ class Chef
       end
 
       def mysql_cmd
-        connection = if admin_mysql_ifaces =~ /\.sock/
-                       iface = admin_mysql_ifaces.split(';').select { |inf| inf =~ /\.sock/ }
-                       "--socket #{iface.first}"
+        admin_ifaces = admin_mysql_ifaces.split(';').map(&:strip)
+        socket_iface = admin_ifaces.select { |i| i =~ /\.sock/ }.first
+
+        connection = if socket_iface
+                       "--socket #{socket_iface}"
                      else
-                       host, port = admin_mysql_ifaces.split(':')
+                       host, port = admin_ifaces.first.split(':')
                        "--host #{host} --port #{port}"
                      end
         user, pass = admin_credentials.split(':')

--- a/metadata.rb
+++ b/metadata.rb
@@ -7,7 +7,7 @@ long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 issues_url 'https://github.com/vinted/chef-proxysql/issues'
 source_url 'https://github.com/vinted/chef-proxysql'
 chef_version '>= 12.1' if respond_to?(:chef_version)
-version '3.4.0'
+version '3.4.1'
 
 supports 'redhat'
 supports 'centos'

--- a/test/integration/roles/admin_variables.json
+++ b/test/integration/roles/admin_variables.json
@@ -5,7 +5,7 @@
       "config": {
         "admin_variables": {
           "admin_credentials": "admin:admin",
-          "mysql_ifaces": "127.0.0.1:6033"
+          "mysql_ifaces": "127.0.0.1:6033;127.0.0.1:29029;127.0.0.1:39099;"
         }
       }
     }


### PR DESCRIPTION
Addressing https://github.com/vinted/chef-proxysql/issues/29

> Hey, can this be reopened? I am seeing a similar problem but using two IP addresses in the mysql_ifaces variable:
> 
> ```
> mysql_ifaces: '127.0.0.1:6032;10.10.10.10:6032'
> ```
> Will produce a string like:
> 
> ```
> mysql --user="admin" --password="admin" --host 127.0.0.1 --port 6032;10.10.10.10
> ```
> The code doesn't take into affect multiple interface declarations (that are not sockets)
> [chef-proxysql/libraries/proxysql_service.rb](https://github.com/vinted/chef-proxysql/blob/6b1150547c53e81d02c44964c459d49e8cef1ba8/libraries/proxysql_service.rb#L190-L193)
> 
> Lines 190 to 193 in [6b11505](/vinted/chef-proxysql/commit/6b1150547c53e81d02c44964c459d49e8cef1ba8)
> 
>  else 
>    host, port = admin_mysql_ifaces.split(':') 
>    "--host #{host} --port #{port}" 
>  end 
> At the moment I can work around this by adding an extra socket declaration to the mysql_ifaces variable

