### PR TITLE
Rename percona node attribute namespace to proxysql

### DIFF
--- a/attributes/repository.rb
+++ b/attributes/repository.rb
@@ -1,13 +1,13 @@
-default['percona']['repository']['name'] = 'percona-original-release.repo'
+default['proxysql']['repository']['name'] = 'percona-original-release.repo'
 
 case node['platform']
 when 'rhel', 'centos'
-  default['percona']['repository']['url'] = 'http://repo.percona.com/yum/percona-release-latest.noarch.rpm'
+  default['proxysql']['repository']['url'] = 'http://repo.percona.com/yum/percona-release-latest.noarch.rpm'
 when 'debian', 'ubuntu'
   lsb_release = Mixlib::ShellOut.new('lsb_release -sc')
   lsb_release.run_command
   lsb_release.error!
   lsb_release = lsb_release.stdout.chomp
 
-  default['percona']['repository']['url'] = "http://repo.percona.com/apt/percona-release_latest.#{lsb_release}_all.deb"
+  default['proxysql']['repository']['url'] = "http://repo.percona.com/apt/percona-release_latest.#{lsb_release}_all.deb"
 end

--- a/libraries/base_service.rb
+++ b/libraries/base_service.rb
@@ -95,8 +95,8 @@ class Chef
 
       # rubocop:disable Metrics/AbcSize
       def install_proxysql_repository
-        url = node['percona']['repository']['url']
-        name = node['percona']['repository']['name']
+        url = node['proxysql']['repository']['url']
+        name = node['proxysql']['repository']['name']
 
         case node['platform']
         when 'rhel', 'centos'
@@ -105,24 +105,24 @@ class Chef
           end
         when 'ubuntu', 'debian'
           basename = ::File.basename(url)
-          percona_repo_deb = Chef::Config[:file_cache_path] + "/#{basename}"
+          repo_deb = Chef::Config[:file_cache_path] + "/#{basename}"
 
           # Using execute because apt_update is available only in Chef Client 12.7.
-          execute 'apt_update_for_percona_repo' do
+          execute 'apt_update_for_repo' do
             command %(apt-get update)
             action :nothing
           end
 
           dpkg_package basename do
-            source percona_repo_deb
+            source repo_deb
             action :nothing
-            notifies :run, 'execute[apt_update_for_percona_repo]', :immediate
+            notifies :run, 'execute[apt_update_for_repo]', :immediate
           end
 
-          remote_file percona_repo_deb do
+          remote_file repo_deb do
             source url
             notifies :install, "dpkg_package[#{basename}]", :immediate
-            not_if { ::File.exist?(percona_repo_deb) }
+            not_if { ::File.exist?(repo_deb) }
           end
         end
       end

--- a/metadata.rb
+++ b/metadata.rb
@@ -7,7 +7,7 @@ long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 issues_url 'https://github.com/vinted/chef-proxysql/issues'
 source_url 'https://github.com/vinted/chef-proxysql'
 chef_version '>= 12.1' if respond_to?(:chef_version)
-version '3.4.1'
+version '4.0.0'
 
 supports 'redhat'
 supports 'centos'


### PR DESCRIPTION
Remove root namespace node attribute 'percona' to 'proxysql' to avoid conflict with other cookbooks 