### PR TITLE
add percona packaging gpg key manual import

### DIFF
--- a/libraries/base_service.rb
+++ b/libraries/base_service.rb
@@ -99,6 +99,9 @@ class Chef
 
         package 'findutils' if node['platform_version'].to_i >= 8
 
+        execute 'import percona repo packaging key' do
+          command 'rpm --import /etc/pki/rpm-gpg/PERCONA-PACKAGING-KEY'
+        end
         execute "rpm -Uhv #{repo['url']}" do
           creates "/etc/yum.repos.d/#{repo['name']}"
         end

--- a/metadata.rb
+++ b/metadata.rb
@@ -5,7 +5,7 @@ license 'MIT'
 description 'Installs/Configures ProxySQL'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 chef_version '>= 12.1' if respond_to?(:chef_version)
-version '5.0.0'
+version '5.0.1'
 
 depends 'poise', '~> 2.8.1'
 depends 'systemd', '~> 3.2.3'


### PR DESCRIPTION
Fixes warning of
```console
STDERR: warning: /var/tmp/rpm-tmp.YiwcgN: Header V4 RSA/SHA256 Signature, key ID 8507efa5: NOKEY
```
when executing `rpm -Uhv #{repo['url']}` in `libraries/base_service.rb`
which writes a warning to STDERR causing a runtime failure.