### PR TITLE
use yum_repository for adding proxysql repository

### DIFF
--- a/attributes/repository.rb
+++ b/attributes/repository.rb
@@ -1,3 +1,4 @@
 default['proxysql']['repository']['name'] = 'percona-original-release.repo'
 default['proxysql']['repository']['url'] = 'http://repo.percona.com/yum/percona-release-latest.noarch.rpm'
+default['proxysql']['repository']['gpgkey'] = 'https://repo.percona.com/yum/PERCONA-PACKAGING-KEY'
 default['proxysql']['package_release'] = "1.1.el#{node['platform_version'].to_i}"

--- a/libraries/base_service.rb
+++ b/libraries/base_service.rb
@@ -43,7 +43,7 @@ class Chef
             create_user
             dirs = [
               new_resource.config_dir,
-              new_resource.data_dir
+              new_resource.data_dir,
             ]
             create_directories(dirs)
             install_proxysql_repository
@@ -64,7 +64,7 @@ class Chef
 
       def platform_supported?
         platform = node['platform']
-        return if %w[centos redhat rocky].include?(platform)
+        return if %w(centos redhat rocky).include?(platform)
 
         raise "Platform #{platform} is not supported"
       end
@@ -99,8 +99,10 @@ class Chef
 
         package 'findutils' if node['platform_version'].to_i >= 8
 
-        execute "rpm -Uhv #{repo['url']}" do
-          creates "/etc/yum.repos.d/#{repo['name']}"
+        yum_repository repo['name'] do
+          baseurl repo['url']
+          gpgkey repo['gpgkey']
+          action :create
         end
       end
     end

--- a/metadata.rb
+++ b/metadata.rb
@@ -5,7 +5,7 @@ license 'MIT'
 description 'Installs/Configures ProxySQL'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 chef_version '>= 12.1' if respond_to?(:chef_version)
-version '5.0.0'
+version '5.0.1'
 
 depends 'poise', '~> 2.8.1'
 depends 'systemd', '~> 3.2.3'


### PR DESCRIPTION
Use `yum_repository` chef resource instead of `rpm Uhv` because it fails if percona package is already installed.
Also auto-formatting rubocop changes.