### PR TITLE
Revert previous fix and pin percona-release to compatible version

### DIFF
--- a/attributes/repository.rb
+++ b/attributes/repository.rb
@@ -1,4 +1,3 @@
 default['proxysql']['repository']['name'] = 'percona-original-release.repo'
-default['proxysql']['repository']['url'] = 'http://repo.percona.com/yum/percona-release-latest.noarch.rpm'
-default['proxysql']['repository']['gpgkey'] = 'https://repo.percona.com/yum/PERCONA-PACKAGING-KEY'
+default['proxysql']['repository']['url'] = 'https://repo.percona.com/yum/percona-release-1.0-9.noarch.rpm'
 default['proxysql']['package_release'] = "1.1.el#{node['platform_version'].to_i}"

--- a/libraries/base_service.rb
+++ b/libraries/base_service.rb
@@ -99,10 +99,8 @@ class Chef
 
         package 'findutils' if node['platform_version'].to_i >= 8
 
-        yum_repository repo['name'] do
-          baseurl repo['url']
-          gpgkey repo['gpgkey']
-          action :create
+        execute "rpm -Uhv #{repo['url']}" do
+          creates "/etc/yum.repos.d/#{repo['name']}"
         end
       end
     end

--- a/metadata.rb
+++ b/metadata.rb
@@ -5,7 +5,7 @@ license 'MIT'
 description 'Installs/Configures ProxySQL'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 chef_version '>= 12.1' if respond_to?(:chef_version)
-version '5.0.1'
+version '5.0.2'
 
 depends 'poise', '~> 2.8.1'
 depends 'systemd', '~> 3.2.3'


### PR DESCRIPTION
Revert previous fix and pin percona-release to compatible version. Upgrade to newer `percona-release` version will require bigger rework.